### PR TITLE
Add USB Nugget config file for Keyboard PID/VID & WiFi creds

### DIFF
--- a/src/RubberNugget/RubberNugget.ino
+++ b/src/RubberNugget/RubberNugget.ino
@@ -28,7 +28,7 @@ bool webstuffhappening = false;
 
 extern Nugget_Interface payloadSelector;
 
-Adafruit_NeoPixel strip {1, 12, NEO_GRB + NEO_KHZ400 };
+Adafruit_NeoPixel strip (1, 12, NEO_RGB + NEO_KHZ800);
 
 const char *ssid = "Nugget AP";
 const char *password = "nugget123";
@@ -186,7 +186,9 @@ void webserverInit(void *p) {
 }
 
 void setup() {
-  pinMode(12, OUTPUT); delay(500);
+  pinMode(12, OUTPUT); 
+  strip.begin(); 
+  delay(500);
   Serial.begin(115200);
 
   WiFi.softAP(ssid, password);
@@ -204,9 +206,15 @@ void setup() {
 
   server.begin();
 
-  strip.begin(); strip.clear(); strip.show();
-  strip.setPixelColor(0, strip.Color(0, 0, 0)); strip.show();
-  strip.setBrightness(100);
+  
+  // delay(400);
+
+  strip.clear(); 
+  strip.setPixelColor(0, strip.Color(0, 0, 0)); 
+  strip.show();
+  strip.show();
+
+  // strip.setBrightness(100);
 
   // initialize & launch payload selector
   RubberNugget::init();

--- a/src/makefile
+++ b/src/makefile
@@ -34,3 +34,15 @@ generate_img: check_port build
 
 check_port:
 	@ls $(PORT) || { echo "Device not found at $(PORT). Run with 'make flash PORT=<port>'" && exit 1; }
+
+# export_binary:
+# 	docker create --name $(CONTAINER_NAME) --device=$(PORT) -t rubber-nugget:latest
+# 	docker start $(CONTAINER_NAME)
+# 	docker exec $(CONTAINER_NAME) bash -c \
+# 	'./arduino-cli compile -b esp32:esp32:esp32s2 --output-dir / --build-property build.partitions=noota_3gffat --build-property build.cdc_on_boot=1 RubberNugget/  \
+# 	&& ls /'
+
+# 	docker cp $(CONTAINER_NAME):/RubberNugget.ino.bin /tmp/meow.bin
+# 	docker rm --force $(CONTAINER_NAME)
+
+


### PR DESCRIPTION
Not sure we'll have time to fully review this.  
But this feature allows you to create a `usbnugget.conf` file on the NUGGET flash drive that lets you set the`VID` & `PID` of the Nugget keyboard, and also the WiFi AP credentials.