### PR TITLE
Add software development doc

### DIFF
--- a/docs/dev/software_development_process.md
+++ b/docs/dev/software_development_process.md
@@ -1,4 +1,4 @@
-# USBNugget software development process
+# USB Nugget software development process
 
 ## 1. Work planning and task creation
 
@@ -51,7 +51,8 @@ Implementing larger features may require updates to documentation.
 Documentation should be updated alongside implementation of these features in
 the same commit or PR.
 - Product-specific documentation in the README file in the project directory root.
-- Developer-specific documentation belongs in `/src/docs`. It should be written in markdown.
+- Developer-specific documentation belongs in `/docs/dev`. It should be written
+  in markdown.
 
 ### Write comments as needed
 See [best practices for writing code comments](https://stackoverflow.blog/2021/12/23/best-practices-for-writing-code-comments/)


### PR DESCRIPTION
If github doesn't automatically generate a doc preview, try this link: https://github.com/HakCat-Tech/USB-Nugget/blob/748ae9402f42db90aeb1716c20633942d40b2729/docs/dev/software_development_process.md