### PR TITLE
lock esptool version

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update && apt-get install -y \
     bsdmainutils \
     xz-utils \
     python3 python3-pip
-RUN pip3 install pyserial esptool
+RUN pip3 install pyserial esptool==4.2.1
 
 ARG ARDUINO_CLI_VERSION=0.22.0
 RUN wget https://github.com/arduino/arduino-cli/releases/download/${ARDUINO_CLI_VERSION}/arduino-cli_${ARDUINO_CLI_VERSION}_Linux_64bit.tar.gz
@@ -27,7 +27,7 @@ RUN ./third_party/arduino_cli_install.sh $(readlink -f ./arduino-cli)
 # Patch to force esptool to use no_reset option. This is necessary because
 # arduino-cli does not provide an option to forward this flag. This may become
 # unncessary when esp32s2 is better supported.
-RUN sed -i '/.*args = parser.parse_args(argv)/a\ \ \ \ args.after="no_reset"' /root/.arduino15/packages/esp32/tools/esptool_py/3.3.0/esptool.py
+RUN sed -i '/.*args = parser.parse_args(argv)/a\ \ \ \ args.after="no_reset"' $(grep -r parser.parse_args /root/.arduino15/packages/esp32/tools/esptool_py/ -l)
 
 COPY RubberNugget ./RubberNugget
 COPY fatfs/default.img .


### PR DESCRIPTION
1. Lock the version of esptool
2. Make the patch of esptool version-independent so it's less likely we need to change two things when updating esptool