### PR TITLE
fix memory leak in NuggetInterface

### DIFF
--- a/src/RubberNugget/src/interface/lib/NuggetInterface.h
+++ b/src/RubberNugget/src/interface/lib/NuggetInterface.h
@@ -46,6 +46,7 @@ class NuggetInterface;
 class NuggetScreen {
    public:
       NuggetScreen();
+      virtual ~NuggetScreen(){};
       virtual bool draw() = 0;
       virtual int update(int){return SCREEN_NONE;};
       void setDisplay(SH1106Wire*);


### PR DESCRIPTION
The destructor of a base class should be virtual to avoid memory leaks
See https://stackoverflow.com/a/461224 for more info