### PR TITLE
fix: web builder adds null terminator

### DIFF
--- a/src/scripts/build_web_ui.sh
+++ b/src/scripts/build_web_ui.sh
@@ -12,7 +12,8 @@ fileToProgmem() {
     echo "#pragma once"
     xxd -i "$file" \
         | sed "s/.*\[\].*/const char $varname\[\] PROGMEM = {/g" \
-        | sed -E "s/unsigned int.*( = .*)/const int ${varname}_len\1/g"
+        | sed -E "s/unsigned int.*( = .*)/const int ${varname}_len\1/g" \
+        | sed -E 's/(.*0x..$.*)/\1, 0x00/g' # add null terminator
 }
 
 for file in $(find ../RubberNugget/webUI -type f); do


### PR DESCRIPTION
In release 1.2, the web UI shows the string "resume" in the web UI. Image: https://i.imgur.com/NbEYPMR.png

This is because
1. there is no null terminator in the array constructed by `src/scripts/build_web_ui.sh`
2. We pass this array directly to a String constructor when the web ui is requested
3. The String constructor doesn't provide options for array length and expects it to be null terminated.

Easiest solution: have `build_web_ui.sh` append a null byte 